### PR TITLE
Add compatibility UUIDs for Xcode 6.4 beta 2, 6.3.2 GM.

### DIFF
--- a/BetaWarpaint/Info.plist
+++ b/BetaWarpaint/Info.plist
@@ -30,6 +30,7 @@
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
+		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>

--- a/BetaWarpaint/Info.plist
+++ b/BetaWarpaint/Info.plist
@@ -29,6 +29,7 @@
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
This includes the new `DVTPlugInCompatibilityUUID` value from the following command: 

```
$ defaults read /Applications/Xcode-beta.app/Contents/Info DVTPlugInCompatibilityUUID
```

This is required for Xcode 6.4 beta 2 to recognize the plugin (and subsequently request to load it upon first launch).
